### PR TITLE
Bootstrap KinD clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,23 @@
 # Tekton Remote Pipelines
 
 Run Tekton Pipelines on remote, connected clusters.
+
+## Getting Started
+
+### Prerequisites
+
+- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl) and
+  [kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/)
+- [KinD](https://kind.sigs.k8s.io/)
+- [clusteradm](https://open-cluster-management.io/getting-started/installation/register-a-cluster/#install-clusteradm-cli-tool)
+
+### Setup
+
+1. Run `hack/bootstrap-kind.sh` to create a hub cluster and remote cluster with KinD.
+   This will create a hub cluster (`hub`) and one remote cluster (`remote-east`).
+2. Follow the instructions from [Open Cluster Management](https://open-cluster-management.io/getting-started/installation/register-a-cluster/)
+   to boostrap a Klusterlet for KinD. _Note: stop after the managed cluster_
+   _issues the join command_.
+3. Run `hack/register-remote.sh` to finish the setup process on the managed cluster.
+
+See [setup](docs/setup.md) for more information.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,21 @@
+# Setup
+
+Reference information for the setup scripts.
+## hack/boostrap-kind.sh
+
+Script to boostrap a "hub" and "remote" cluster with KinD.
+
+Available options (via environment variables:)
+
+* `KIND_CMD` - provide an alternate command to run KinD. Default: `kind`
+* `CLUSTERADM_CMD` - provide and alternate command to run `clusteradm`. Default: `clusteradm`
+* `KUBECTL_CMD` - provide an alternate command to run `kubectl`. Default: `kubectl`
+
+## hack/register-remote.sh
+
+Register the remote ("managed") cluster with the hub cluster.
+
+Available options (via environment variables:)
+
+* `CLUSTERADM_CMD` - provide and alternate command to run `clusteradm`. Default: `clusteradm`
+* `KUBECTL_CMD` - provide an alternate command to run `kubectl`. Default: `kubectl`

--- a/hack/bootstrap-kind.sh
+++ b/hack/bootstrap-kind.sh
@@ -1,0 +1,29 @@
+#! /bin/bash
+
+# Copyright 2023 The Tekton Remote Pipeline Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Bootstrap a KinD environment with a hub and remote ("managed") cluster
+
+set -e
+
+kind=${KIND_CMD:-kind}
+clusteradm=${CLUSTERADM_CMD:-clusteradm}
+kubectl=${KUBECTL_CMD:-kubectl}
+
+echo "Creating KinD clusters 'hub' and 'remote-east'"
+${kind} create cluster --name hub
+${kind} create cluster --name remote-east
+
+${clusteradm} init --wait --context kind-hub
+
+echo "OCM Control Plane Status:"
+${kubectl} -n open-cluster-management get pod --context kind-hub
+
+echo "OCM Hub Control Plane Status:"
+${kubectl} -n open-cluster-management-hub get pod --context kind-hub
+
+echo "Adding application manager to hub cluster"
+${clusteradm} install hub-addon --names application-manager --context kind-hub
+${kubectl} -n open-cluster-management get deploy multicluster-operators-subscription --context kind-hub

--- a/hack/register-remote.sh
+++ b/hack/register-remote.sh
@@ -1,0 +1,28 @@
+#! /bin/bash
+
+# Copyright 2023 The Tekton Remote Pipeline Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Register the remote ("managed") cluster to the hub cluster
+
+set -e
+
+clusteradm=${CLUSTERADM_CMD:-clusteradm}
+kubectl=${KUBECTL_CMD:-kubectl}
+
+echo "Checking the CSR status of the managed clusters"
+${kubectl} get csr -w --context kubectl get csr -w --context kind-hub
+
+echo "Accepting the remote cluster on the hub"
+${clusteradm} accept --clusters remote-east --context kind-hub
+
+echo "Checking status of the managed cluster"
+${kubectl} -n open-cluster-management-agent get pod --context kind-remote-east
+
+echo "Adding application manager to remote cluster"
+${kubectl} create ns open-cluster-management-agent-addon --context kind-remote-east
+${clusteradm} addon enable --names application-manager --clusters remote-east --context kind-hub
+
+echo "Checking status of application manager"
+${kubectl} -n remote-east get managedclusteraddon --context kind-hub


### PR DESCRIPTION
- Create scripts to boostrap a KinD environment with two clusters (hub and managed)
- Add setup instructions in README, with details in a separate doc.